### PR TITLE
Fixed db_connect and con vars

### DIFF
--- a/Seltzer/crm/api/db.inc.php
+++ b/Seltzer/crm/api/db.inc.php
@@ -8,14 +8,20 @@ $crm_root = realpath(dirname(__FILE__) . '/..');
 // This brings in the global variables like the host, user, pw, etc.
 require_once($crm_root . '/include/crm.inc.php');
 
-// Create the DB connection for SQL queries
-$con=mysqli_connect($config_db_host,$config_db_user,$config_db_password,$config_db_db);
+// $db_connect should already be set by the incldues above.
+if (is_null($db_connect))
+{
+  // Create the DB connection for SQL queries
+  $db_connect=mysqli_connect($config_db_host,$config_db_user,$config_db_password,$config_db_db) or die(mysqli_connect_error());
+}
+
+//Seltzer uses $db_connect, but my scripts call it $con.
+$con = $db_connect;
+global $db_connect;
 
 // Check connection
 if (mysqli_connect_errno()) {
   echo "Failed to connect to MySQL DB: " . mysqli_connect_error();
 }
-
-//echo "Connected OK! <br>";
 
 ?>

--- a/Seltzer/crm/api/query.php
+++ b/Seltzer/crm/api/query.php
@@ -106,7 +106,8 @@ function getMemberLastPaymentTimestamp($rfid)
 function getRFIDWhitelist()
 {
 	require('db.inc.php');
-	
+	$db_connect = $con;
+
 	$whiteList = array();
 	
 	//get everyone's plan prices and balances and check here
@@ -141,8 +142,9 @@ function getRFIDWhitelist()
 // their current montly plan price, FALSE or error string if not.
 function doorLockCheck($rfid)
 {
-	require('db.inc.php');
-	
+ 	require('db.inc.php');
+	$db_connect = $con;
+  
 	$rfid = testInput($rfid);
 	
 	//get the key owner and their current membership plan


### PR DESCRIPTION
In newest PHP 8.3.11 the way the db connections are brought down from includes are different. The db.inc.php now checks if the db_connect is null before trying to connect again.  query.php now copies the db_connect var to the con variable so it can be used throughout.